### PR TITLE
fix: allow force proxy CIDRs in TUN mode

### DIFF
--- a/box/scripts/box.iptables
+++ b/box/scripts/box.iptables
@@ -23,6 +23,8 @@ proxy_tcp=${proxy_tcp:-"true"}
 proxy_udp=${proxy_udp:-"true"}
 dns_hijack_tcp=${dns_hijack_tcp:-"true"}
 dns_hijack_udp=${dns_hijack_udp:-"true"}
+tun_force_proxy_cidrs=(${tun_force_proxy_cidrs[@]})
+tun_force_proxy_cidrs6=(${tun_force_proxy_cidrs6[@]})
 fake_ip_range=""
 fake_ip6_range=""
 stack="${stack:-gvisor}"
@@ -279,6 +281,8 @@ runtime_save() {
     printf 'bypass_cn_ip="%s"\n' "${bypass_cn_ip}"
     printf 'bypass_cn_ip_v4="%s"\n' "${bypass_cn_ip_v4}"
     printf 'bypass_cn_ip_v6="%s"\n' "${bypass_cn_ip_v6}"
+    printf 'tun_force_proxy_cidrs=(%s)\n' "${tun_force_proxy_cidrs[*]}"
+    printf 'tun_force_proxy_cidrs6=(%s)\n' "${tun_force_proxy_cidrs6[*]}"
     printf 'box_user="%s"\n' "${box_user}"
     printf 'box_group="%s"\n' "${box_group}"
   } >"${runtime_iptables_env}" 2>/dev/null
@@ -1051,6 +1055,22 @@ append_tun_fake_ip_route_rules() {
 
   ensure_rule_append mangle "${chain_name}" -d "${fake_range}" -j MARK --set-xmark "${tun_route_mark}"
   ensure_rule_append mangle "${chain_name}" -d "${fake_range}" -j RETURN
+}
+
+append_tun_force_proxy_destination_rules() {
+  local chain_name="$1"
+
+  if [ "${iptables}" = "$IPV" ]; then
+    for subnet in ${tun_force_proxy_cidrs[@]} ; do
+      [ -n "${subnet}" ] || continue
+      append_mark_and_return_rule mangle "${chain_name}" "${tun_route_mark}" -d "${subnet}"
+    done
+  else
+    for subnet6 in ${tun_force_proxy_cidrs6[@]} ; do
+      [ -n "${subnet6}" ] || continue
+      append_mark_and_return_rule mangle "${chain_name}" "${tun_route_mark}" -d "${subnet6}"
+    done
+  fi
 }
 
 append_tun_bypass_destination_rules() {
@@ -2314,11 +2334,13 @@ start_tun_bypass() {
 
   ensure_rule_append mangle "${pre_chain}" -i "${tun_device}" -j RETURN
   append_tun_dns_rules "${pre_chain}"
+  append_tun_force_proxy_destination_rules "${pre_chain}"
   append_tun_bypass_destination_rules "${pre_chain}"
 
   append_tun_core_bypass_rules "${out_chain}"
   append_tun_dns_rules "${out_chain}"
   append_cnip_force_proxy_tun_rules "${out_chain}"
+  append_tun_force_proxy_destination_rules "${out_chain}"
   append_tun_proxy_mode_rules "${out_chain}"
   append_tun_bypass_destination_rules "${out_chain}"
 

--- a/box/settings.ini
+++ b/box/settings.ini
@@ -76,6 +76,10 @@ bypass_cn_ip_v4="false"
 bypass_cn_ip_v6="false"
 # CNIP 例外应用
 cnip_force_proxy_apps=()
+# TUN 强制代理目标网段（在内网/CNIP 绕过前进入 TUN；例如通过内核代理的 Tailscale/Home LAN 场景）
+# 示例: tun_force_proxy_cidrs=(192.168.1.0/24 192.168.0.0/24 100.64.0.0/10)
+tun_force_proxy_cidrs=()
+tun_force_proxy_cidrs6=()
 cn_ip_file="${box_run_state}/cn_ip.txt"
 cn_ipv6_file="${box_run_state}/cn_ipv6.txt"
 cn_ip_url="https://ispip.clang.cn/all_cn.txt"


### PR DESCRIPTION
## Summary

Add configurable TUN force-proxy destination CIDRs.

When TUN mode and CNIP bypass are enabled, private or carrier-grade NAT ranges such as `192.168.0.0/16` and `100.64.0.0/10` are returned by intranet bypass rules before they can enter the proxy core. This breaks scenarios where the core itself provides an overlay-network outbound, for example mihomo's `tailscale` proxy for Home LAN access.

This PR adds:

- `tun_force_proxy_cidrs`
- `tun_force_proxy_cidrs6`

These CIDRs are marked with `tun_route_mark` before intranet/CNIP/UID bypass rules, so selected destinations can still enter the TUN and be handled by core routing rules.

Default values are empty, so existing behavior is unchanged.

## Example

```sh
tun_force_proxy_cidrs=(192.168.1.0/24 192.168.0.0/24 100.64.0.0/10)
tun_force_proxy_cidrs6=()
```

## Tested

Tested on Android root + mihomo TUN mode with CNIP bypass enabled. Bare access to Home LAN via mihomo's Tailscale outbound works while CNIP bypass remains enabled.